### PR TITLE
Performance tweaks for signing

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for Net-Amazon-Signature-v4
 
+		- Additional patch by Arthur Axel fREW Schmidt:
+			- Use Time::Piece instead of DateTime for date formatting/parsing.
+			- Avoid parsing the date at all if the user allowed it to be defaulted,
+			  and if we do parse it, only parse it once.
+
 0.15_02 2017-03-31
 		- Additional patch by Steven Hartland (RT#100964):
 			- Ensures the Host header is always present, as its required.

--- a/lib/Net/Amazon/Signature/V4.pm
+++ b/lib/Net/Amazon/Signature/V4.pm
@@ -229,7 +229,7 @@ sub _str_to_datetime {
 		return strptime( '%Y%m%dT%H%M%SZ', $date );
 	} else {
 		# assume the format given in the AWS4 test suite
-		$date =~ s/^.{4}//; # remove weekday, as Amazon's test suite contains internally inconsistent dates
+		$date =~ s/^.{5}//; # remove weekday, as Amazon's test suite contains internally inconsistent dates
 		return strptime(  '%d %b %Y %H:%M:%S %Z', $date );
 	}
 }


### PR DESCRIPTION
 * I removed DateTime parsing/formatting in favor of Time::Piece, which shaved
   off almost a millisecond in my tests.

 * I also made some changes to, when defaulting the date, use the value we
   defaulted as our date object instead of parsing the defaulted date.

 * Finally I cached the underlying Time::Piece object instead of generating a
   new one on each access.

For posterity; even after these changes 9% of the time doing sqs:SendMessage is
spent in signing and about 5% is spent parsing XML.  The rest of the time is
spent doing HTTP.

The signing time seems to be a lot of calls to header, the internal
_sort_query_string, and the internal _trim_whitespace.

I would be happy to attempt to make those last three faster but I don't see
obvious ways.

